### PR TITLE
Rename JSONiq grammar scope to `source.jsoniq`

### DIFF
--- a/grammars/jsoniq.cson
+++ b/grammars/jsoniq.cson
@@ -1,4 +1,4 @@
-'scopeName': 'source.jq'
+'scopeName': 'source.jsoniq'
 'fileTypes': [
   'jq'
 ]

--- a/grammars/xquery.cson
+++ b/grammars/xquery.cson
@@ -15,7 +15,7 @@
         'begin': '^(?=jsoniq\\s+version\\s+)'
         'end': '\\z'
         'patterns': [
-            'include': 'source.jq'
+            'include': 'source.jsoniq'
         ]
     }
     {
@@ -142,7 +142,7 @@
             }
             {
                 'match': '=',
-                'name': 'source.jq'
+                'name': 'source.jsoniq'
             }
             {
                 'begin': '\''

--- a/lib/language-jsoniq.js
+++ b/lib/language-jsoniq.js
@@ -34,7 +34,7 @@ module.exports = (function(_super) {
         _super.call(this, editor);
     }
     __extends(JSONiqLinter, _super);
-    JSONiqLinter.syntax = ['source.jq', 'source.xq'];
+    JSONiqLinter.syntax = ['source.jsoniq', 'source.xq'];
     JSONiqLinter.prototype.linterName = 'xqlint';
 
     JSONiqLinter.prototype.lintFile = function(filePath, callback){

--- a/snippets/language-jsoniq.cson
+++ b/snippets/language-jsoniq.cson
@@ -1,4 +1,4 @@
-'.source.jq':
+'.source.jsoniq':
   'for':
     'prefix': 'for'
     'body': 'for $${1:item} in ${2:expr}${3}'

--- a/spec/jsoniq-spec.js
+++ b/spec/jsoniq-spec.js
@@ -9,12 +9,12 @@ describe('JSONiq Grammar', function() {
             return atom.packages.activatePackage('language-jsoniq');
         });
         return runs(function() {
-            return grammar = atom.grammars.grammarForScopeName('source.jq');
+            return grammar = atom.grammars.grammarForScopeName('source.jsoniq');
         });
     });
 
     it('parses the grammar', function() {
         expect(grammar).toBeTruthy();
-        return expect(grammar.scopeName).toBe('source.jq');
+        return expect(grammar.scopeName).toBe('source.jsoniq');
     });
 });


### PR DESCRIPTION
The name `source.jq` conflicts with another format, one also named "JQ". Having both grammars installed in tandem will cause problems for users, and has also raised a complication over at [Linguist](https://github.com/github/linguist) (which uses this repository to highlight JSONiq files on GitHub).

See [`github/linguist#5233`](https://github.com/github/linguist/pull/5233#issuecomment-789242773) for the discussion that led to this PR.

(I should point out that a grammar's `scopeName` field should be treated like a unique identifier; hence it's best to pick a scope that's the most specific and unambiguous…)